### PR TITLE
Smaller container (fixes #56)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,3 @@ LICENSE
 
 screenshot.png
 Godeps/
-
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+output.log

--- a/container-make.sh
+++ b/container-make.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -x
+
+CONTAINER_NAME=${1}
+CONTAINER_TAG=${2}
+
+PROJECT_NAME='github.com/tobegit3hub/seagull'
+PROJECT_DIR="${PWD}"
+VENDOR_DIR='Godeps/_workspace'
+
+CONTAINER_GOPATH='/go'
+CONTAINER_PROJECT_DIR="${CONTAINER_GOPATH}/src/${PROJECT_NAME}"
+CONTAINER_PROJECT_GOPATH="${CONTAINER_PROJECT_DIR}/${VENDOR_DIR}:${CONTAINER_GOPATH}"
+
+docker run --rm \
+        -v ${PROJECT_DIR}:${CONTAINER_PROJECT_DIR} \
+        -e GOPATH=${CONTAINER_PROJECT_GOPATH} \
+        -e CGO_ENABLED=0 \
+        -e GODEBUG=netdns=go \
+        -w "${CONTAINER_PROJECT_DIR}" \
+        golang:1.5.3-alpine \
+        go build -v -o seagull seagull.go
+
+# Disable this to strip the debug information from the binary and shave off about 4Mb making the binary from 12mb to 8mb
+# It means this can't be debugged by delve, gdb et al. but the side is even better
+strip "${PROJECT_DIR}/seagull"
+
+docker build -f ${PROJECT_DIR}/seagull.docker \
+    -t ${CONTAINER_NAME}:${CONTAINER_TAG} \
+    --build-arg BINARY_FILE=./seagull \
+    "${PROJECT_DIR}"

--- a/container-release.sh
+++ b/container-release.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -x
+
+CONTAINER_NAME=${1}
+CONTAINER_TAG=${2}
+
+PROJECT_DIR="${PWD}"
+
+${PROJECT_DIR}/container-make.sh "${CONTAINER_NAME}" "${CONTAINER_TAG}"
+
+# TODO docker tag command should go here
+
+# TODO docker push command should go here

--- a/container-test.sh
+++ b/container-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -x
+
+PROJECT_NAME='github.com/tobegit3hub/seagull'
+PROJECT_DIR="${PWD}"
+VENDOR_DIR='Godeps/_workspace'
+
+CONTAINER_GOPATH='/go'
+CONTAINER_PROJECT_DIR="${CONTAINER_GOPATH}/src/${PROJECT_NAME}"
+CONTAINER_PROJECT_GOPATH="${CONTAINER_PROJECT_DIR}/${VENDOR_DIR}:${CONTAINER_GOPATH}"
+
+docker run --rm \
+    --net="host" \
+    -v ${PROJECT_DIR}:${CONTAINER_PROJECT_DIR} \
+    -e CI=true \
+    -e GODEBUG=netdns=go \
+    -e GOPATH=${CONTAINER_PROJECT_GOPATH} \
+    -w "${CONTAINER_PROJECT_DIR}" \
+    golang:1.5.3 \
+    go test -v -race ./... 2> output.log
+
+EXIT_CODE=$?
+
+cat output.log
+
+if [ ${EXIT_CODE} != 0 ]; then
+    rm -f output.log
+    exit ${EXIT_CODE} 
+fi
+
+# Check for race conditions as we don't have a proper exit code for them from the tool
+cat output.log | grep -v 'WARNING: DATA RACE'
+
+EXIT_CODE=$?
+
+rm -f output.log
+
+# If we don't find a match then we don't have a race condition
+if [ ${EXIT_CODE} == 1 ]; then
+    exit 0
+fi
+
+exit ${EXIT_CODE}

--- a/seagull.docker
+++ b/seagull.docker
@@ -1,0 +1,22 @@
+FROM alpine:3.3
+MAINTAINER tobe "tobeg3oogle@gmail.com"
+MAINTAINER Florin Patan "florinpatan@gmail.com"
+
+ARG BINARY_FILE
+
+# DNS stuff
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+# SSL certs
+RUN apk add --update ca-certificates \
+    && rm -rf /var/cache/apk/*
+
+# Binary
+ADD conf/app.conf /seagull/conf/app.conf
+COPY views /seagull/views
+COPY static /seagull/static
+ADD $BINARY_FILE /seagull/seagull
+
+# Runtime
+EXPOSE 10086
+CMD ["/seagull/seagull"]


### PR DESCRIPTION
Hi,

Thank you for the great project.

This PR does the following two things:
- updates the dependencies and adds the missing ones (needed for step 2)
- improves the testing and release process by making the containers as small as possible

*Please note*: This disables CGO and forces the application to use the Go dns resolver not the system one (which should be ok). Also, the debug information is stripped away from the binary so that the size is reduced by ~33%.

With the changes I've made, the new container drops from ~560mb to ~18mb, see the screenshot below: 
![snapshot221](https://cloud.githubusercontent.com/assets/607868/13036327/b530b644-d364-11e5-962e-5715f2b57531.png)

The new workflow would be like this:
- run tests ` /container-test.sh `
- build the container ` ./container-make.sh <container-name> <container-tag> ` (for example: ` ./container-make.sh dlsniper/seagull 13 `
- release the container ` ./container-release <container-name> <container-tag> ` (for example ` ./container-make.sh dlsniper/seagull 13`

*Please note*: the release process is not finished as I don't know what the docker tag and push commands you are currently using / maybe there are some other env variables / docker login action you have to do first. Please change this after merging.

Looking forward for comments / getting this merged.

Kind regards.

(fixes #56)